### PR TITLE
Experimental migration generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ def deps do
 end
 ```
 
+## Database migration
+Here we use the repo example name of `Dinarly`:
+
+```
+mix ex_locale.gen_ex_locale_migration Dinarly
+```
+
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/ex_locale](https://hexdocs.pm/ex_locale).
-

--- a/lib/mix/ex_locale.gen_ex_locale_migration.ex
+++ b/lib/mix/ex_locale.gen_ex_locale_migration.ex
@@ -1,0 +1,35 @@
+defmodule Mix.Tasks.ExLocale.GenExLocaleMigration do
+  use Mix.Task
+
+  alias Mix.{Project, Generator}
+
+  @shortdoc "Creates the migration needed by ExLocale"
+
+  @moduledoc """
+  Creates the storage for the ExLocale, where it keeps id, name and
+  activation status information. You must provide the name of the repo as an argument.
+  """
+
+   @doc false
+   def run(args) do
+    if Project.umbrella? do
+      Mix.raise "mix ex_locale.gen_ex_locale_migration can only be run inside an application directory"
+    end
+
+    {_opts, [repo], []} = OptionParser.parse(args)
+
+    source = Application.app_dir :ex_locale, "priv/migrations/ex_locale.exs"
+    target = "priv/repo/migrations/#{timestamp()}_init_ex_locale.exs"
+    binding = [repo: repo]
+    Generator.create_file(target, EEx.eval_file(source, binding))
+    IO.puts "Please run `mix ecto.migrate!`"
+  end
+
+  defp timestamp do
+    {{y, m, d}, {hh, mm, ss}} = :calendar.universal_time()
+    "#{y}#{pad(m)}#{pad(d)}#{pad(hh)}#{pad(mm)}#{pad(ss)}"
+  end
+
+  defp pad(i) when i < 10, do: << ?0, ?0 + i >>
+  defp pad(i), do: to_string(i)
+end

--- a/lib/mix/ex_locale.gen_exlocale_migration.ex
+++ b/lib/mix/ex_locale.gen_exlocale_migration.ex
@@ -16,7 +16,6 @@ defmodule Mix.Tasks.ExLocale.GenExLocaleMigration do
       Mix.raise "mix ex_locale.gen_ex_locale_migration can only be run inside an application directory"
     end
 
-    IO.puts args
     {_opts, [repo], []} = OptionParser.parse(args, switches: [debug: :boolean])
 
     source = Application.app_dir :ex_locale, "priv/migrations/ex_locale.exs"

--- a/lib/mix/ex_locale.gen_exlocale_migration.ex
+++ b/lib/mix/ex_locale.gen_exlocale_migration.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.ExLocale.GenExLocaleMigration do
    @doc false
    def run(args) do
     if Project.umbrella? do
-      Mix.raise "mix ex_locale.gen_ex_locale_migration can only be run inside an application directory"
+      Mix.raise "mix exlocale.gen_ex_locale_migration can only be run inside an application directory"
     end
 
     {_opts, [repo], []} = OptionParser.parse(args)

--- a/lib/mix/ex_locale.gen_exlocale_migration.ex
+++ b/lib/mix/ex_locale.gen_exlocale_migration.ex
@@ -16,6 +16,7 @@ defmodule Mix.Tasks.ExLocale.GenExLocaleMigration do
       Mix.raise "mix ex_locale.gen_ex_locale_migration can only be run inside an application directory"
     end
 
+    IO.puts args
     {_opts, [repo], []} = OptionParser.parse(args, switches: [debug: :boolean])
 
     source = Application.app_dir :ex_locale, "priv/migrations/ex_locale.exs"

--- a/lib/mix/ex_locale.gen_exlocale_migration.ex
+++ b/lib/mix/ex_locale.gen_exlocale_migration.ex
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.ExLocale.GenExLocaleMigration do
       Mix.raise "mix ex_locale.gen_ex_locale_migration can only be run inside an application directory"
     end
 
-    {_opts, [repo], []} = OptionParser.parse(args)
+    {_opts, [repo], []} = OptionParser.parse(["--debug"], switches: [debug: :boolean], args)
 
     source = Application.app_dir :ex_locale, "priv/migrations/ex_locale.exs"
     target = "priv/repo/migrations/#{timestamp()}_init_ex_locale.exs"

--- a/lib/mix/ex_locale.gen_exlocale_migration.ex
+++ b/lib/mix/ex_locale.gen_exlocale_migration.ex
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.ExLocale.GenExLocaleMigration do
       Mix.raise "mix ex_locale.gen_ex_locale_migration can only be run inside an application directory"
     end
 
-    {_opts, [repo], []} = OptionParser.parse(args, ["--debug"], switches: [debug: :boolean])
+    {_opts, [repo], []} = OptionParser.parse(args, switches: [debug: :boolean])
 
     source = Application.app_dir :ex_locale, "priv/migrations/ex_locale.exs"
     target = "priv/repo/migrations/#{timestamp()}_init_ex_locale.exs"

--- a/lib/mix/ex_locale.gen_exlocale_migration.ex
+++ b/lib/mix/ex_locale.gen_exlocale_migration.ex
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.ExLocale.GenExLocaleMigration do
       Mix.raise "mix ex_locale.gen_ex_locale_migration can only be run inside an application directory"
     end
 
-    {_opts, [repo], []} = OptionParser.parse(["--debug"], switches: [debug: :boolean], args)
+    {_opts, [repo], []} = OptionParser.parse(args, ["--debug"], switches: [debug: :boolean])
 
     source = Application.app_dir :ex_locale, "priv/migrations/ex_locale.exs"
     target = "priv/repo/migrations/#{timestamp()}_init_ex_locale.exs"

--- a/lib/mix/ex_locale.gen_exlocale_migration.ex
+++ b/lib/mix/ex_locale.gen_exlocale_migration.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.ExLocale.GenExLocaleMigration do
    @doc false
    def run(args) do
     if Project.umbrella? do
-      Mix.raise "mix exlocale.gen_ex_locale_migration can only be run inside an application directory"
+      Mix.raise "mix ex_locale.gen_ex_locale_migration can only be run inside an application directory"
     end
 
     {_opts, [repo], []} = OptionParser.parse(args)

--- a/priv/migrations/ex_locale.exs
+++ b/priv/migrations/ex_locale.exs
@@ -1,0 +1,11 @@
+defmodule <%= repo %>.Migrations.ExLocale do
+  use Ecto.Migration
+
+  def change do
+    create table(:exlocale_locales, primary_key: false) do
+      add :id, :text, primary_key: true, null: false
+      add :name, :text, null: false, default: ""
+      add :active, :boolean, default: false
+    end
+  end
+end

--- a/priv/migrations/ex_locale.exs
+++ b/priv/migrations/ex_locale.exs
@@ -6,6 +6,7 @@ defmodule <%= repo %>.Migrations.ExLocale do
       add :id, :text, primary_key: true, null: false
       add :name, :text, null: false, default: ""
       add :active, :boolean, default: false
+      add :translations, :map
     end
   end
 end


### PR DESCRIPTION
This is the initial work to add experimental migration generation. Here we use the repo example name of `Dinarly`:

```
mix ex_locale.gen_ex_locale_migration Dinarly
```

Please run `mix ecto.migrate`